### PR TITLE
Removed publicData from default scopes.

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -48,7 +48,7 @@ function Strategy(options, verify) {
   options = options || {};
   options.authorizationURL = options.authorizationURL || 'https://login.eveonline.com/v2/oauth/authorize/';
   options.tokenURL = options.tokenURL || 'https://login.eveonline.com/v2/oauth/token';
-  options.scope = options.scope || 'publicData';
+  options.scope = options.scope || '';
 
   OAuth2Strategy.call(this, options, verify);
   this._oauth2.useAuthorizationHeaderforGET(true);


### PR DESCRIPTION
When defining no scopes (like for an auth bot) you get an error saying there is no scope `publicData`. Removing it from the default scope lets people use an ESI application without any scopes defined without errors.